### PR TITLE
adds composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "jr00ck/gravity-forms-edit-entries",
+  "description": "Allows editing Gravity Forms entries on your site using shortcodes. Uses [gf-edit-entries] shortcode. Also provides a link to edit an entry using [gf-edit-entries-link] shortcode.",
+  "keywords": ["wordpress", "plugin", "jr00ck", "gravity-forms"],
+  "homepage": "https://github.com/jr00ck/gravity-forms-edit-entries.git",
+  "license": "GNU",
+  "authors": [{
+    "name": "Jeremy Saxey",
+    "homepage": "http://freeupwebstudio.com"
+  }],
+  "type": "wordpress-plugin",
+  "require": {
+    "composer/installers": "^1.0.6"
+  }
+}


### PR DESCRIPTION
I'd like to pull your plugin in via composer. It's not on wpackagist.org.
This adds composer support, for those using trellis/sage.

Notes on installation: composer.json
```
"repositories": [
    {
      "type": "composer",
      "url": "https://wpackagist.org"
    },
    {
      "type" : "vcs",
      "url" : "https://github.com/jr00ck/gravity-forms-edit-entries.git"
    }
  ],
  "require": {
    "jr00ck/gravity-forms-edit-entries" : "*"
  },
```
I've tested on my fork, works fine.
